### PR TITLE
feat: ☁️ improve migrate script

### DIFF
--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -3,9 +3,8 @@ import {drizzle} from 'drizzle-orm/vercel-postgres'
 import {migrate} from 'drizzle-orm/vercel-postgres/migrator'
 import {
   ULIDGenerateFunction,
-  UpdatedAtTriggerFunction,
-  NotesTableTrigger,
-  UsersTableTrigger,
+  UpdatedAtFunction,
+  AddUpdatedAtTrigger,
 } from './utils'
 
 async function migrateToLatest() {
@@ -19,18 +18,17 @@ async function migrateToLatest() {
     console.log('🔧 DB_FUNCTION: Create generate_ulid() function')
     await ULIDGenerateFunction
 
-    console.log('⚡ DB_TRIGGER: Create trigger for updated_at column')
-    await UpdatedAtTriggerFunction
+    console.log('🔧 DB_FUNCTION: Create auto-update updated_at column function')
+    await UpdatedAtFunction
 
-    console.log('✨ DB_TABLE: Add trigger to tables')
-    await UsersTableTrigger
-    await NotesTableTrigger
+    console.log('⚡ DB_TABLE: Add trigger to tables')
+    await AddUpdatedAtTrigger
 
     console.log('\nMigrating...\n')
     await migrate(db, {migrationsFolder: './drizzle'})
     console.log('✅ Migration was executed successfully!')
   } catch (error) {
-    console.error('Migration failed! ', error)
+    console.error('___\nMigration failed! ', error)
     process.exit(1)
   }
 


### PR DESCRIPTION
Adding auto-update trigger for all tables with `updated_at` column is now possible  without modifying the `migrate` script.