### PR TITLE
fix: 🔧 apiMiddleware return unauthenticated when locale specified

### DIFF
--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -12,7 +12,9 @@ export default function Error({
     <div className="flex-center h-full flex-col gap-8">
       <div className="text-center">
         <h1>Something went wrong!</h1>
-        <p className="mt-4 text-sm text-zinc-400">{error.digest}</p>
+        <p className="mt-4 text-sm text-zinc-400">
+          {error.digest} {error.digest ? '' : error.message}
+        </p>
       </div>
 
       <button

--- a/app/[locale]/global-error.tsx
+++ b/app/[locale]/global-error.tsx
@@ -5,14 +5,12 @@ import type {ServerError} from '~/types'
 export default function GlobalError({
   error,
   reset,
-  params: {locale},
 }: {
   error: ServerError
   reset: () => void
-  params: {locale: string}
 }) {
   return (
-    <html lang={locale}>
+    <html lang="en">
       <body className="flex-center h-[100dvh] flex-col gap-4 font-inter">
         <div className="text-center">
           <h1>Something went wrong!</h1>

--- a/components/layouts/navbar.tsx
+++ b/components/layouts/navbar.tsx
@@ -124,8 +124,9 @@ export default function Navbar({appName, signOutLabel}: NavProps) {
                   as="div"
                   className={`flex items-center rounded-full ${renderAvatar.container}`}
                   menuClassName="hidden md:block"
-                  itemsClassName="z-10 w-48"
+                  itemsClassName="w-48"
                   items={desktopMenuItems}
+                  floatOptions={{portal: true}}
                 >
                   <span className="sr-only">Open user menu</span>
                   {renderAvatar.avatar}

--- a/components/note/note-editor.tsx
+++ b/components/note/note-editor.tsx
@@ -108,7 +108,7 @@ export default function NoteEditor({
       injectCSS: false,
       autofocus: autofocus,
     },
-    [id, initialValue, disabled],
+    [id, initialValue],
   )
 
   if (!textEditor) {

--- a/util/index.ts
+++ b/util/index.ts
@@ -43,6 +43,10 @@ export async function fetcher<ResponseData>(
       throw new Error(res.statusText)
     }
 
+    if (res.redirected) {
+      redirect(res.url)
+    }
+
     throw new Error('Response data is not supported')
   }
 


### PR DESCRIPTION
`authMiddleware` returns `intlMiddleware` if authenticated. 
If a locale is specified, `response.ok` from it is always `false`.